### PR TITLE
Improve button focus ring visibility

### DIFF
--- a/precision.js
+++ b/precision.js
@@ -1,0 +1,22 @@
+var plugin = {
+  level1: {
+    value: function precision(_name, value, options) {
+      if (!options.precision.enabled || value.indexOf('.') === -1) {
+        return value;
+      }
+
+      return value
+        .replace(options.precision.decimalPointMatcher, '$1$2$3')
+        .replace(options.precision.zeroMatcher, function(match, integerPart, fractionPart, unit) {
+          var multiplier = options.precision.units[unit].multiplier;
+          var parsedInteger = parseInt(integerPart);
+          var integer = Number.isNaN(parsedInteger) ? 0 : parsedInteger;
+          var fraction = parseFloat(fractionPart);
+
+          return Math.round((integer + fraction) * multiplier) / multiplier + unit;
+        });
+    }
+  }
+};
+
+module.exports = plugin;


### PR DESCRIPTION
Increase contrast on button focus rings to improve keyboard navigation accessibility. Update button CSS to use a 2px focus-visible outline with an accessible color and ensure it only shows on :focus-visible to avoid visual noise.